### PR TITLE
修复了由于路径中含有空格而无法安装的错误

### DIFF
--- a/install.py
+++ b/install.py
@@ -124,11 +124,18 @@ def install():
         makedirs(path.join(MCPYPATH, "lib", version))
     if ("--skip-install-requirements" not in argv) and ("--travis-ci" not in argv):
         print("[Install requirements]")
-        pip = "\"%s\" -m pip" % executable
+        def processing_space(file_path):
+            array = file_path.split("\\")
+            for item in array:
+                if ' ' in item:
+                    array[array.index(item)] = "\"" + item + "\""
+            return "\\".join(array)
+        pip = "%s -m pip" % processing_space(executable)
+        requirements_path = get_file("requirements.txt")
         if "--hide-output" in argv:
-            code = system("%s install -U -r %s >> %s" % (pip, get_file("requirements.txt"), path.devnull))
+            code = system("%s install -U -r \"%s\" >> %s" % (pip, requirements_path, path.devnull))
         else:
-            code = system("%s install -U -r %s" % (pip, get_file("requirements.txt")))
+            code = system("%s install -U -r \"%s\"" % (pip, requirements_path))
         if code != 0:
             print("pip raise error code: %d" % code)
             exit(1)


### PR DESCRIPTION
形如`"C:\Program Files\Python310\python.exe" -m pip install -U -r C:\Users\chufeng\Saved Games\minecraft\requirements.txt`是无法正常运行的，有两个原因：
1. 就算`C:\Program Files\Python310\python.exe`整体加了双引号，仍然会报`C:\Program`的错，具体原因不明，解决方法就是只给有空格的文件或文件夹加引号，变成这样：`C:\"Program Files"\Python310\python.exe`
2. `-r` 后边的参数是给 pip 用的字符串，所以既不能用上面的方法，也不能直接写上去，所以需要加上双引号，防止空格被识别为命令分隔符
最后会生成这样的命令：`C:\"Program Files"\Python310\python.exe -m pip install -U -r "C:\Users\chufeng\Saved Games\minecraft\requirements.txt"`
这样就能正常安装了